### PR TITLE
Added test scene with attach_screen

### DIFF
--- a/Game.tscn
+++ b/Game.tscn
@@ -3,83 +3,25 @@
 [ext_resource path="res://icon.png" type="Texture" id=1]
 
 [sub_resource type="ParticlesMaterial" id=1]
-
-render_priority = 0
-trail_divisor = 1
-emission_shape = 0
-flag_align_y = false
-flag_rotate_y = false
 flag_disable_z = true
 spread = 0.0
-flatness = 0.0
 gravity = Vector3( 0, -1000, 0 )
-initial_velocity = 0.0
-initial_velocity_random = 0.0
-angular_velocity = 0.0
-angular_velocity_random = 0.0
 orbit_velocity = 0.0
 orbit_velocity_random = 0.0
-linear_accel = 0.0
-linear_accel_random = 0.0
-radial_accel = 0.0
-radial_accel_random = 0.0
-tangential_accel = 0.0
-tangential_accel_random = 0.0
-damping = 0.0
-damping_random = 0.0
-angle = 0.0
-angle_random = 0.0
-scale = 1.0
-scale_random = 0.0
-color = Color( 1, 1, 1, 1 )
-hue_variation = 0.0
-hue_variation_random = 0.0
-anim_speed = 0.0
-anim_speed_random = 0.0
-anim_offset = 0.0
-anim_offset_random = 0.0
-anim_loop = false
 
-[node name="Game" type="Node2D" index="0"]
+[node name="Game" type="Node2D"]
 
-[node name="Background" type="TextureRect" parent="." index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Background" type="TextureRect" parent="."]
 margin_right = 1920.0
 margin_bottom = 2160.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 1
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
 texture = ExtResource( 1 )
 expand = true
-stretch_mode = 0
 
-[node name="Particles2D" type="Particles2D" parent="." index="1"]
-
+[node name="Particles2D" type="Particles2D" parent="."]
 position = Vector2( 960, 1620 )
-emitting = true
 amount = 100
 lifetime = 2.0
-one_shot = false
-preprocess = 0.0
-speed_scale = 1.0
-explosiveness = 0.0
-randomness = 0.0
-fixed_fps = 0
-fract_delta = true
-visibility_rect = Rect2( -100, -100, 200, 200 )
-local_coords = true
-draw_order = 0
+visibility_rect = Rect2( -1500, -1500, 3000, 3000 )
 process_material = SubResource( 1 )
 texture = ExtResource( 1 )
-normal_map = null
-h_frames = 1
-v_frames = 1
-
 

--- a/Main.tscn
+++ b/Main.tscn
@@ -60,3 +60,4 @@ margin_right = 1920.0
 margin_bottom = 3240.0
 rect_scale = Vector2( 1, 0.5 )
 texture = SubResource( 6 )
+

--- a/Node.gd
+++ b/Node.gd
@@ -1,0 +1,15 @@
+extends Node
+
+func _ready():
+	#Do not render the main viewport
+	#	Without this the empty main viewport will draw over the others
+	#	becuase it is drawn last
+	get_viewport().set_attach_to_screen_rect(Rect2())
+	
+	#Share world ("Game") between the two viewports
+	$Viewport2.world_2d = $Viewport.world_2d
+	
+	#First viewport will take up the top half of the screen
+	$Viewport.set_attach_to_screen_rect(Rect2(0, 0, 960, 540))
+	#Second viewport takes up the bottom half of the screen
+	$Viewport2.set_attach_to_screen_rect(Rect2(0, 540, 960, 540))

--- a/Node.tscn
+++ b/Node.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Node.gd" type="Script" id=1]
+[ext_resource path="res://Game.tscn" type="PackedScene" id=2]
+
+[node name="Node" type="Node"]
+script = ExtResource( 1 )
+
+[node name="Viewport" type="Viewport" parent="."]
+size = Vector2( 1920, 1080 )
+own_world = true
+
+[node name="Camera2D" type="Camera2D" parent="Viewport"]
+anchor_mode = 0
+current = true
+
+[node name="Game" parent="Viewport" instance=ExtResource( 2 )]
+
+[node name="Viewport2" type="Viewport" parent="."]
+size = Vector2( 1920, 1080 )
+
+[node name="Camera2D" type="Camera2D" parent="Viewport2"]
+position = Vector2( 0, 1080 )
+anchor_mode = 0
+current = true
+

--- a/default_env.tres
+++ b/default_env.tres
@@ -12,3 +12,4 @@ sun_energy = 16.0
 [resource]
 background_mode = 2
 background_sky = SubResource( 1 )
+


### PR DESCRIPTION
The proposed optimization [here](https://github.com/godotengine/godot/issues/26440) relies on using ``VisualServer.viewport_attach_to_screen`` to render viewports directly to the screen instead of through a ``ViewportContainer`` (or in your case a ``TextureRect``). The optimization would avoid having to copy the screen multiple times as your ``Viewport`` is transferred to the root-Viewport then the root-Viewport is transferred to the screen. 

This PR establishes a sample case that uses ``attach_to_screen`` instead of ``TextureRects`` so that I could get a good baseline for how much the optimization actually improves rendering. As it turns out, **without the optimization**, just using ``attach_to_screen`` decreases rendering time dramatically. 

### Performance Comparison
I tested on a chromebook with an Intel(R) Celeron(R) CPU  N2840  @ 2.16GHz processor and integrated graphics in GLES3 and Godot version 3.1.

On "Main.tscn" I was fluctuating between about 30-40ms for render time (~25-35 fps). This is due to the sheer size of the render target involved. 

Performance increased dramatically using "Node.tscn" **without optimization**. In "Node.tscn" I got a stable 15-20ms render time (50-60 fps). Again, the sheer size of the render target makes these numbers unsurprising. 

### Explanation.
In "Main.tscn" you render the entire thing to a giant (1920, 2160) viewport and then slice it up using texture rects. Under the hood the process is:
1. Render to Viewport ->
2. Read from Viewport, render to root->
3. copy from root to screen.

In "Node.tscn" the process is:
1. Render to Viewport 1 + Render to Viewport 2 ->
2. copy Viewport 1 to screen + Copy Viewport 2 to screen.

Root is never used so you skip an entire step. Each step represents a significant change in GPU state (which is the slowest part of rendering), also since Viewport 1 and 2 combined are equal in size to Viewport rendering both takes about the same time as just rendering the one. 

Without the optimization, using ``attach_to_screen`` already provides huge performance gains. 

#### The Optimization
The proposed optimization will even further increase render times by turning the process in Node. tscn into:
1. Render Viewport 1 to screen + Render Viewport 2 to screen.

Please let me know if you would like a detailed explanation about how "Node.tscn" works, I would be happy to explain the process.