### PR TITLE
Updated resizing code for Node.tscn

### DIFF
--- a/Game.gd
+++ b/Game.gd
@@ -12,6 +12,10 @@ func _ready():
 	window_resize()
 
 func window_resize():
+	## For this to work with the optimization the project window size
+	### needs to be the same as the actual window size and the Viewport
+	### size needs to be half the window size
+	## e.g. Window (3840, 1080) and each Viewport (1920, 1080)
 	var current_size = get_viewport().size
 	
 	var scale_factor = minimum_size.y / current_size.y

--- a/Main.tscn
+++ b/Main.tscn
@@ -41,7 +41,6 @@ viewport_path = NodePath("Viewport")
 script = ExtResource( 1 )
 
 [node name="Viewport" type="Viewport" parent="."]
-editor/display_folded = true
 size = Vector2( 1920, 2160 )
 transparent_bg = true
 render_target_v_flip = true

--- a/Node.gd
+++ b/Node.gd
@@ -1,15 +1,59 @@
 extends Node
 
+# I have written this to work with the 3840x1080 physical device you have described
+
+#  *--------------*
+#  |              |       *--------------*--------------*
+#  |        t     |       |              |              |
+#  *--------------*   ->  |         b    |        t     |
+#  |              |       *--------------*--------------*
+#  |        b     |
+#  *--------------*
+
 func _ready():
-	#Do not render the main viewport
-	#	Without this the empty main viewport will draw over the others
-	#	becuase it is drawn last
+	# Tell root Viewport not to render
 	get_viewport().set_attach_to_screen_rect(Rect2())
+
+	# Share world ("Game") between the two viewports
+	$Top.world_2d = $Bottom.world_2d
+
+	get_viewport().connect("size_changed", self, "handle_size_changed")
+	handle_size_changed()
+#
+func handle_size_changed():
+	# Modify size becuase of the layout of the physical device
+	# current_size is the size of each viewport in window coordinates
+	var current_size = OS.get_window_size()
 	
-	#Share world ("Game") between the two viewports
-	$Viewport2.world_2d = $Viewport.world_2d
-	
-	#First viewport will take up the top half of the screen
-	$Viewport.set_attach_to_screen_rect(Rect2(0, 0, 960, 540))
-	#Second viewport takes up the bottom half of the screen
-	$Viewport2.set_attach_to_screen_rect(Rect2(0, 540, 960, 540))
+	# Viewport size is ignored when using the optimization, but we set the size of each viewport
+	# to the size that ("Game") is being rendered to so we don't have to modify code in ("Game")
+	$Top.size = Vector2(0.5, 2.0) * current_size
+	$Bottom.size = Vector2(0.5, 2.0) * current_size
+
+	current_size.x /= 2
+
+	var minimum_size = Vector2(1920, 1080)
+
+	# This calculation stays the same
+	var scale_factor = minimum_size.y / current_size.y
+	var new_size = Vector2(current_size.x * scale_factor, minimum_size.y)
+
+	# I used current_size to calculate the scaling here as we require the scale
+	# between the current_size and new_size in order to zoom the cameras correctly
+	if new_size.x < minimum_size.x:
+		scale_factor = minimum_size.x / current_size.x
+		new_size = Vector2(minimum_size.x, current_size.y * scale_factor)
+
+	# The big difference now is that you need to move the cameras to capture
+	# the Part of the game you want, and you have to set the position of the
+	# Viewports manually rather than letting the TextureRect handle the scaling
+	# for you
+	$Bottom/Camera2D.zoom = Vector2(scale_factor, scale_factor)
+	$Top/Camera2D.zoom = Vector2(scale_factor, scale_factor)
+	$Bottom/Camera2D.position = Vector2(0, new_size.y)
+	$Top/Camera2D.position = Vector2(0, 0)
+
+	# Bottom is drawn on the left half of the screen, while Top is drawn
+	# on the Right. These sizes need to be in relation to the actual window size
+	$Bottom.set_attach_to_screen_rect(Rect2(0, 0, current_size.x, current_size.y))
+	$Top.set_attach_to_screen_rect(Rect2(current_size.x, 0, current_size.x, current_size.y))

--- a/Node.tscn
+++ b/Node.tscn
@@ -6,21 +6,23 @@
 [node name="Node" type="Node"]
 script = ExtResource( 1 )
 
-[node name="Viewport" type="Viewport" parent="."]
+[node name="Bottom" type="Viewport" parent="."]
 size = Vector2( 1920, 1080 )
 own_world = true
+render_direct_to_screen = true
 
-[node name="Camera2D" type="Camera2D" parent="Viewport"]
+[node name="Camera2D" type="Camera2D" parent="Bottom"]
+position = Vector2( 100, 100 )
 anchor_mode = 0
 current = true
 
-[node name="Game" parent="Viewport" instance=ExtResource( 2 )]
+[node name="Game" parent="Bottom" instance=ExtResource( 2 )]
 
-[node name="Viewport2" type="Viewport" parent="."]
+[node name="Top" type="Viewport" parent="."]
 size = Vector2( 1920, 1080 )
+render_direct_to_screen = true
 
-[node name="Camera2D" type="Camera2D" parent="Viewport2"]
+[node name="Camera2D" type="Camera2D" parent="Top"]
 position = Vector2( 0, 1080 )
 anchor_mode = 0
 current = true
-

--- a/project.godot
+++ b/project.godot
@@ -30,5 +30,6 @@ window/stretch/mode="2d"
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
 environment/default_environment="res://default_env.tres"
 quality/dynamic_fonts/use_oversampling=false


### PR DESCRIPTION
This took a little longer than I expected. I wanted the code to be as similar as possible to the code in Main.tscn and the least intrusive possible. Here is what I have come up with. 

You will have to use the structure set up in Node.tscn. So that means two Viewports (with render direct to screen turned on) each with their own Camera2D. When you update the screen size you do three things differently

1) Update the size of each Viewport to equal the size of the virtual screen. While the size of the Viewport is going to be ignored when using the optimization, Game.gd expects to get the full virtual screen size when it updates, so set the Viewports size to facilitate that.

2) Set the Camera2D's ``zoom`` property to the ``scale_factor``. When we render direct to screen the Viewport essentially takes the size of the window dimensions it covers, if the virtual screen is a different size from the window, then we need to zoom in or out to scale the scene.

3) ``set_attach_to_screen_rect()`` we manually tell each Viewport which area of the screen to cover.

Let me know if you have any questions about this implementation. 

Also, when you test it out, I suggest changing the Particles2D to CPUParticles2D so they appear in GLES2 (you do so by selecting the Particles2D node then clicking "Particles" in the top bar and selecting "Convert to CPUParticles") on my low-end device at the full 3840x1080 resolution the optimization increased FPS from 40 to 80. This isn't a good comparison because my screen is only 1366x768, but it shows much promise!!